### PR TITLE
Running cordova prepare on projectRoot as cwd.

### DIFF
--- a/src/server/prepare.js
+++ b/src/server/prepare.js
@@ -24,7 +24,7 @@ function prepare() {
         try {
             projectRoot = config.projectRoot;
         } catch (error) {
-            projectRoot = process.cwd();
+            return Q.reject(error);
         }
 
         exec('cordova prepare ' + platform, {

--- a/src/server/prepare.js
+++ b/src/server/prepare.js
@@ -20,7 +20,16 @@ function prepare() {
 
         lastPlatform = platform;
 
-        exec('cordova prepare ' + platform, function (err, stdout, stderr) {
+        var projectRoot;
+        try {
+            projectRoot = config.projectRoot;
+        } catch (error) {
+            projectRoot = process.cwd();
+        }
+
+        exec('cordova prepare ' + platform, {
+            cwd: projectRoot
+        }, function (err, stdout, stderr) {
             lastPlatform = null;
             preparePromise = null;
             if (err) {


### PR DESCRIPTION
Hi @TimBarham! This PR fixes starting simulation of a cordova app with the optional configuration `dir` pointing to a valid cordova project.

When starting simulation with the dir option to specify the cordova app as cwd, by following the documentation specified in the [README.md](https://github.com/Microsoft/taco-simulate#api), the validation of the projectRoot is done right, but when `cordova prepare` command is executed, it runs in the node process current working directory, assuming that the cwd is the actual cordova project. So prepare is ignoring the projectRoot configured to start the simulation. 
To fix this, I've updated the execution to take into account the cordova project directory specified on the configuration: `config.projectRoot`, and launching TACO-simulate from any directory and specifying the cordova dir works:
```
var simulate = require('taco-simulate');
simulate({ dir: '/some/valid/path/to/my/cordova/project/' })
    .then(function () {
        /* some implementation here */
    })
    .fail(function (error) {
        /* some error handling logic */
    });
```

Thanks!