### PR TITLE
Adding simulation implementation for cordova-plugin-battery-status.

### DIFF
--- a/src/plugins/cordova-plugin-battery-status/battery.js
+++ b/src/plugins/cordova-plugin-battery-status/battery.js
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+var db = require('db'),
+    constants = require('sim-constants');
+
+var _callbacks = {
+        sendPluginResult: null,
+        error: null
+    },
+    _batteryInfo = {};
+
+var battery = {
+    listenerEnabled: false,
+
+    initialize: function (message) {
+        _batteryInfo.level = db.retrieve(constants.BATTERY_STATUS.BATTERY_STATUS_KEY) || 100;
+        _batteryInfo.isPlugged = db.retrieve(constants.BATTERY_STATUS.IS_PLUGGED_KEY) || true;
+    },
+
+    /**
+     * Update the current battery level, save it and then notify using the callback passed on
+     * Battery.start call.
+     * @param {number} level
+     */
+    updateBatteryLevel: function (level) {
+        _batteryInfo.level = level;
+
+        db.save(constants.BATTERY_STATUS.BATTERY_STATUS_KEY, level);
+
+        notifyBatteryStatusChanged();
+    },
+
+    /**
+     * Update the current plugged state.
+     * @param {boolean} isPlugged
+     */
+    updatePluggedStatus: function (isPlugged) {
+        _batteryInfo.isPlugged = isPlugged;
+        db.save(constants.BATTERY_STATUS.IS_PLUGGED_KEY, isPlugged);
+    },
+
+    /**
+     * The exec call to Battery.start executes this function.
+     * @param {function} success The function used to simulate the native call to CallbackContext.sendPluginResult.
+     * @param {function} error The function used to simulate the native call to CallbackContext.error
+     */
+    onBatteryStart: function (success, error) {
+        if (battery.listenerEnabled) {
+            error('Battery listener already running.');
+        }
+
+        battery.listenerEnabled = true;
+        _callbacks.sendPluginResult = success;
+        _callbacks.error = error;
+
+        notifyBatteryStatusChanged();
+    },
+
+    /**
+     * The exec call to Battery.stop executes this function.
+     */
+    onBatteryStop: function () {
+        battery.listenerEnabled = false;
+        _callbacks.sendPluginResult = null;
+        _callbacks.error = null;
+    },
+
+    /**
+     * Get a battery info object that defines two properties: isPlugged and level.
+     * @return {object}
+     */
+    getBatteryInfo: function () {
+        return _batteryInfo;
+    }
+};
+
+/**
+ * Executes the success callback when listenerEnabled is true and a valid callback function
+ * is registered. The current batteryInfo object is sent as the result.
+ * This function simulates the native side and call to CallbackContext.sendPluginResult.
+ */
+function notifyBatteryStatusChanged() {
+    if (battery.listenerEnabled && (typeof _callbacks.sendPluginResult === 'function')) {
+        _callbacks.sendPluginResult(battery.getBatteryInfo());
+    }
+}
+
+module.exports = battery;

--- a/src/plugins/cordova-plugin-battery-status/sim-host-handlers.js
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-handlers.js
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = function (messages) {
+    var battery = require('./battery');
+
+    return {
+        Battery: {
+            start: function (success, error) {
+                battery.onBatteryStart(success, error);
+            },
+            stop: function () {
+                battery.onBatteryStop();
+            }
+        }
+    };
+};

--- a/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
+++ b/src/plugins/cordova-plugin-battery-status/sim-host-panels.html
@@ -1,0 +1,19 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved. -->
+
+<cordova-panel id="battery-status" caption="Battery Status">
+    <style>
+        #battery-level-label {
+            margin-right: 5px;
+            margin-left: auto;
+        }
+    </style>
+    <cordova-group>
+        <cordova-panel-row>
+            <cordova-label label="Battery level"></cordova-label>
+            <cordova-label id="battery-level-label" label="100%"></cordova-label>
+            <input id="battery-level" type="range" value="100" min="0" max="100" style="width:130px;">
+        </cordova-panel-row>
+    </cordova-group>
+
+    <cordova-checkbox id="is-plugged" checked>Device plugged</cordova-checkbox>
+</cordova-panel>

--- a/src/plugins/cordova-plugin-battery-status/sim-host.js
+++ b/src/plugins/cordova-plugin-battery-status/sim-host.js
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+module.exports = function (message) {
+    var battery = require('./battery');
+
+    battery.initialize();
+
+    function initialize() {
+        var labelBatteryLevel = document.getElementById('battery-level-label'),
+            levelRange        = document.getElementById('battery-level'),
+            pluggedCheckbox   = document.getElementById('is-plugged');
+
+        function updateBatterLevelText(level) {
+            labelBatteryLevel.textContent = level + '%';
+        }
+
+        // Initialize the UI with the values of isPlugged and battery level.
+        var info = battery.getBatteryInfo();
+        pluggedCheckbox.checked = info.isPlugged;
+        levelRange.value = info.level;
+        updateBatterLevelText(info.level);
+
+        // attach event listeners
+        levelRange.addEventListener('change', function () {
+            battery.updateBatteryLevel(this.value);
+        });
+
+        levelRange.addEventListener('input', function () {
+            updateBatterLevelText(this.value);
+        });
+
+        pluggedCheckbox.addEventListener('click', function () {
+            battery.updatePluggedStatus(this.checked);
+        });
+    }
+
+    return {
+        initialize: initialize
+    };
+};


### PR DESCRIPTION
Hi @TimBarham ! I've developed as part of this PR the simulation implementation of the cordova core plugin battery-status.
I checked how ripple does it, but I wanted to try and propose a different kind of simulation.
In this implementation, instead of letting the simulation to fire the `batterystatus`, `batterylow` and `batterycritical` events based on the changes from the simulation UI, is the actual navigator.battery instance who fires the event. To do that, the simulation implementation is based on the native logic of the plugin. On `Battery.start` exec call I save the success and error callbacks and use them to simulate the native call to `CallbackContext.sendPluginResult` and `CallbackContext.error`. So, the navigator.battery._start and navigator.battery._error callbacks are executed and the logic of firing the event based on the battery level and thresholds values defined, remains a responsibility of the plugin itself. If in an update the thresholds values are updated, we do not need to update the simulation code.

Thanks!